### PR TITLE
Merchants with most revenue

### DIFF
--- a/app/controllers/api/v1/merchants/business_intel_controller.rb
+++ b/app/controllers/api/v1/merchants/business_intel_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::Merchants::BusinessIntelController < ApplicationController
   def index
-    Merchant.most_revenue(revenue_params)
-    render json: MerchantSerializer.new(Merchant)
+    merchant = Merchant.most_revenue(revenue_params)
+    render json: MerchantSerializer.new(merchant)
   end
 
   private

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -21,8 +21,11 @@ class Merchant < ApplicationRecord
 
   def self.most_revenue(merchant_quantity)
     merchant_limit = merchant_quantity.values.first.to_i
-    # Merchant.joins(:invoices).joins(:transactions).where(transactions: {result: "success"})
-     merchants = Merchant.joins(invoices: [:invoice_items, :transactions]).where("transactions.result = 'success'").group("merchants.name").select("merchants.name, sum(invoice_items.quantity * invoice_items.unit_price) as revenue")
-     require "pry"; binding.pry
+    Merchant.select("merchants.*, SUM(invoice_items.quantity * invoice_items.unit_price) AS revenue")
+    .joins(invoices: [:invoice_items, :transactions])
+    .where(transactions: {result: "success"})
+    .group("merchants.id")
+    .order("revenue desc")
+    .limit(merchant_limit)
   end
 end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,3 +1,3 @@
-class Transaction <ApplicationRecord
+class Transaction < ApplicationRecord
   belongs_to :invoice
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -36,7 +36,6 @@ FactoryBot.define do
     status {"shipped"}
     association :merchant
     association :customer
-    association :transactions
   end
 end
 
@@ -50,8 +49,8 @@ FactoryBot.define do
 end
 
 FactoryBot.define do
-  factory :transactions do
-    creadit_card_number {rand(4000000000000000..5000000000000000)}
+  factory :transaction do
+    credit_card_number {rand(4000000000000000..5000000000000000)}
     credit_card_expiration_date { " " }
     result {rand("success", "failed")}
     association :invoice

--- a/spec/requests/api/v1/merchants/merchants_business_intelligence_request_spec.rb
+++ b/spec/requests/api/v1/merchants/merchants_business_intelligence_request_spec.rb
@@ -5,29 +5,33 @@ describe "Merchants Business Intelligence" do
     m1= create(:merchant)
     item1=  create(:item, merchant: m1)
     inv_item = create(:invoice_item, item: item1, unit_price:100.00)
-    inv = create(:invoice, invoice_item: inv_item)
+    inv = create(:invoice, merchant: m1)
+    transaction1 = create(:transaction, result: "failed", invoice: inv)
 
     m2 = create(:merchant)
     item2 = create(:item, merchant: m2)
     inv_item2 = create(:invoice_item, item: item2, unit_price:400.00)
-    inv2 = create(:invoice, invoice_item: inv_item2)
+    inv2 = create(:invoice, merchant: m2)
+    transaction2 = create(:transaction, result: "success", invoice: inv2)
 
     m3 = create(:merchant)
     item3 = create(:item, merchant: m3)
-    inv_item3 = create(:invoice_item, item: item3, unit_price:400.00)
-    inv3 = create(:invoice, invoice_item: inv_item3)
+    inv_item3 = create(:invoice_item, item: item3, unit_price:3000.00)
+    inv3 = create(:invoice, merchant: m3)
+    transaction3 = create(:transaction, result: "success", invoice: inv3)
 
     m4 = create(:merchant)
     item4 = create(:item, merchant: m4)
-    inv_item4 = create(:invoice_item, item: item4, unit_price:400.00)
-    inv4 = create(:invoice, invoice_item: inv_item4)
+    inv_item4 = create(:invoice_item, item: item4, unit_price:50.00)
+    inv4 = create(:invoice, merchant: m4)
+    transaction4 = create(:transaction, result: "success", invoice: inv4)
 
-    require "pry"; binding.pry
     get "/api/v1/merchants/most_revenue?quantity=3"
 
     expect(response).to be_successful
     merchants = JSON.parse(response.body)
     expect(merchants["data"]).to eq(3)
-
+    expect(merchants["data"][0]["attributes"]["name"]).to eq(m3.name)
+    expect(merchants["data"][2]["attributes"]["name"]).to eq(m4.name)
   end
 end


### PR DESCRIPTION
Allows user to specify how many merchants to be returned and will send a list of x top merchants with most revenue. Passing spec harness. Not passing locally due to factory bot issues